### PR TITLE
[Epic - Conditional Gitlab Access] @cbrown/1107 add label to namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 istio
 istio-1.5.10/
 profile-state-controller
+
+__debug_bin

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ istio-1.5.10/
 profile-state-controller
 
 __debug_bin
+coverage*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,16 @@
                 "--kubeconfig",
                 "${env:KUBECONFIG}"
             ]
+        },
+        {
+            "name": "Debug Handler Unit Tests",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/pkg/controller/handler_test.go",
+            "env": {},
+            "args": [],
+            "showLog": true
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Profile State Controller",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "cwd": "${workspaceFolder}",
+            "program": "main.go",
+            "args": [
+                "--kubeconfig",
+                "${env:KUBECONFIG}"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,38 @@
-## Profile State Controller
+# Profile State Controller
 
-This controller adds the `state.aaw.statcan.gc.ca/employee-only-features` label to the Profiles based on the Pods in that namespace. 
+The Profile State Controller applies labels to Kubeflow Profiles and Kubernetes namespaces that indicate certain properties of users in those namespaces.
+
+The purpose of this controller is to ensure that profiles/namespaces are correctly labelled so that other applications in the cluster can make allow/deny decisions based on these labels.
+
+The sections below detail specific labels and the logic they use.
+
+## Employee Only Features
+
+This controller adds the `state.aaw.statcan.gc.ca/employee-only-features` label to the Profiles based on the Pods in that namespace.
 If any Pods in that namespace are using a SAS image, it will set the label in the Profile to `true`, otherwise `false`.
 
-This controller also adds the `state.aaw.statcan.gc.ca/non-employee-user` label to the Profiles based on the RoleBindings in that namespace.
-If the RoleBinding shows that the user is external (email does not end with an accepted domain), it will set the label in the Profile to `true` otherwise `false`.
+### Unit Test Cases
+
+1. If **any pod** in a list of pods contains a SAS image, `hasEmployeeOnlyFeatures` should return `true`.
+2. If **no pod** in a list of pods contains a SAS image,  `hasEmployeeOnlyFeatures` should return `false`.
+3. If an empty list is passed to `hasEmployeeOnlyFeatures`, it should return `false`.
+
+## Non-Employee Users
+
+When the owner of a Kubeflow Profile adds a contributor to their namespace, a rolebinding is [created in that namespace](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/#managing-contributors-manually), binding the new contributor to the `kubeflow-edit` role in that namespace.
+
+Specifically, contributors are named by their email address (emails with a StatCan domain are considered employees and all other domains are considered non-employees).
+
+If at any point a contributor with an external email address is added to a Kubeflow Profile, the Profile State Controller sets the label `state.aaw.statcan.gc.ca/non-employee-users=true` on both the Kubeflow Profile and the corresponding namespace.
+
+Other applications on the cluster can use this label to make decisions based on whether namespaces contain non-employee users.
+
+### Unit Test Cases
+
+1. If **any rolebinding** in a list of rolebindings contains a non-employee user, `hasNonEmployeeUser` should return `true`.
+2. If **no rolebinding** in a list of rolebindings contains a non-employee user, `hasNonEmployeeUser` should return `false`.
+3. If an empty list is passed to `hasNonEmployeeUser`, it should return `false`.
+
 
 ### How to Contribute
 
@@ -14,6 +42,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Unless otherwise noted, the source code of this project is covered under Crown Copyright, Government of Canada, and is distributed under the [MIT License](LICENSE).
 
-The Canada wordmark and related graphics associated with this distribution are protected under trademark law and copyright law. 
-No permission is granted to use them outside the parameters of the Government of Canada's corporate identity program. 
+The Canada wordmark and related graphics associated with this distribution are protected under trademark law and copyright law.
+No permission is granted to use them outside the parameters of the Government of Canada's corporate identity program.
 For more information, see [Federal identity requirements](https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,7 @@ vars:
     sh: |
       echo $(cd {{default "./" .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go package(s)"')
   LDFLAGS:
-  CLUSTER_NAME: sas-policy-cluster
+  CLUSTER_NAME: profile-state-controller
   CONTEXT_NAME: "k3d-{{.CLUSTER_NAME}}"
   KUBECTL: "kubectl --context={{.CONTEXT_NAME}}"
   KUBEAPPLY: "{{.KUBECTL}} apply"
@@ -146,13 +146,13 @@ tasks:
 
   create:users:
     prefix: ⚙️ users > create
-    desc: create user namespaces, profiles, and pods 
+    desc: create user namespaces, profiles, and pods
     cmds:
       - task: create:namespaces
       - task: create:pods
       - task: create:profiles
 
-  create:namespaces: 
+  create:namespaces:
     prefix: ⚙️ namespace > create
     desc: create namespaces for users
     cmds:
@@ -165,11 +165,12 @@ tasks:
     desc: create pods in cluster/pods.yaml
     cmds:
       - "{{.KUBEAPPLY}} -f ./cluster/pods.yaml"
-        
+
   create:profiles:
     prefix: ⚙️ profiles > create
     desc: create profiles in cluster/profiles.yaml
     cmds:
+      - "{{.KUBEAPPLY}} -f https://raw.githubusercontent.com/kubeflow/kubeflow/master/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml"
       - "{{.KUBEAPPLY}} -f ./cluster/profiles.yaml"
 
   create:rolebindings:
@@ -177,9 +178,9 @@ tasks:
     desc: create rolebindings in cluster/rolebindings.yaml
     cmds:
       - "{{.KUBEAPPLY}} -f ./cluster/rolebindings.yaml"
-      
+
   go:deploy:
-    desc: build go files and run 
+    desc: build go files and run
     cmds:
       - go build .
       - ./profile-state-controller --kubeconfig ~/.kube/config

--- a/cluster/profiles.yaml
+++ b/cluster/profiles.yaml
@@ -8,17 +8,27 @@ spec:
     name: alice@external.ca
   resourceQuotaSpec: {}
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alice
+---
 apiVersion: kubeflow.org/v1
 kind: Profile
 metadata:
   name: bob
-  labels: 
+  labels:
     test: "true"
 spec:
   owner:
     kind: User
     name: bob@external.ca
   resourceQuotaSpec: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bob
 ---
 apiVersion: kubeflow.org/v1
 kind: Profile
@@ -29,4 +39,9 @@ spec:
     kind: User
     name: sam@external.ca
   resourceQuotaSpec: {}
-
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sam
+---

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,14 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.65.0 // indirect
+	github.com/Azure/go-autorest/autorest v0.9.6 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.8.2 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.2.0 // indirect
+	github.com/Azure/go-autorest/logger v0.1.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bP
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
+cloud.google.com/go v0.65.0 h1:Dg9iHVQfrhq82rUNu9ZxUDrJLaxFUe/HlCVaLyRruq8=
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -33,15 +34,20 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
+github.com/Azure/go-autorest/autorest v0.9.6 h1:5YWtOnckcudzIw8lPPBcWOnmIFWMtHci1ZWAZulMSx0=
 github.com/Azure/go-autorest/autorest v0.9.6/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
+github.com/Azure/go-autorest/autorest/adal v0.8.2 h1:O1X4oexUxnZCaEUGsvMnr8ZGj8HI37tNezwY4npRqA0=
 github.com/Azure/go-autorest/autorest/adal v0.8.2/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
+github.com/Azure/go-autorest/autorest/date v0.2.0 h1:yW+Zlqf26583pE43KhfnhFcdmSWlm5Ew6bxipnr/tbM=
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN3SVSiiO77gL2j2ronKKP0syM=
+github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
+github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VYyQflFE619k=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -65,6 +71,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 		kubeclient,
 		kubeflowclient,
 		kubeflowInformerFactory.Kubeflow().V1().Profiles(),
+		kubeInformerFactory.Core().V1().Namespaces(),
 		kubeInformerFactory.Core().V1().Pods(),
 		kubeInformerFactory.Rbac().V1().RoleBindings(),
 	)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/statcan/profile-state-controller/pkg/signals"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -218,12 +218,6 @@ func (c *Controller) processNextWorkItem() bool {
 }
 
 func (c *Controller) syncHandler(key string) error {
-	//  _                     _ _                             __ _ _
-	// | |__   __ _ _ __   __| | | ___       _ __  _ __ ___  / _(_) | ___
-	// | '_ \ / _` | '_ \ / _` | |/ _ \     | '_ \| '__/ _ \| |_| | |/ _ \
-	// | | | | (_| | | | | (_| | |  __/     | |_) | | | (_) |  _| | |  __/
-	// |_| |_|\__,_|_| |_|\__,_|_|\___|     | .__/|_|  \___/|_| |_|_|\___|
-
 	// Get the profile and namespace associated with the current key.
 	profile, err := c.profileInformerLister.Lister().Get(key)
 	if err != nil {
@@ -251,20 +245,9 @@ func (c *Controller) syncHandler(key string) error {
 
 	isNonEmployeeUser := c.hasNonEmployeeUser(roleBindings)
 	// Handle the profile
-	err = c.handleProfile(profile, hasEmployeeOnlyFeatures, isNonEmployeeUser)
+	err = c.handleProfileAndNamespace(profile, namespace, hasEmployeeOnlyFeatures, isNonEmployeeUser)
 	if err != nil {
-		log.Errorf("failed to handle profile: %v", err)
-		return err
-	}
-	//  _                     _ _
-	// | |__   __ _ _ __   __| | | ___     _ __  ___
-	// | '_ \ / _` | '_ \ / _` | |/ _ \   | '_ \/ __|
-	// | | | | (_| | | | | (_| | |  __/   | | | \__ \
-	// |_| |_|\__,_|_| |_|\__,_|_|\___|   |_| |_|___/
-
-	err = c.handleNamespace(namespace, hasEmployeeOnlyFeatures, isNonEmployeeUser)
-	if err != nil {
-		log.Errorf("failed to handle namespace %v with error: %v", namespace, err)
+		log.Errorf("failed to handle profile or namespace: %v", err)
 		return err
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -226,7 +226,7 @@ func (c *Controller) syncHandler(key string) error {
 	}
 	namespace, err := c.namespaceInformerLister.Lister().Get(key)
 	if err != nil {
-		log.Errorf("failed to get profile %v with error: %v", profile, err)
+		log.Errorf("failed to get namespace %v with error: %v", namespace, err)
 		return err
 	}
 	// Get the pods and rolebindings in the current namespace

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -247,9 +247,9 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 	// Get the status of the profile/namespace
-	hasEmployeeOnlyFeatures := c.hasEmployeeOnlyFeatures(profile, pods)
+	hasEmployeeOnlyFeatures := c.hasEmployeeOnlyFeatures(pods)
 
-	isNonEmployeeUser := c.isNonEmployeeUser(profile, roleBindings)
+	isNonEmployeeUser := c.hasNonEmployeeUser(roleBindings)
 	// Handle the profile
 	err = c.handleProfile(profile, hasEmployeeOnlyFeatures, isNonEmployeeUser)
 	if err != nil {

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -51,7 +51,7 @@ func isEmployee(rolebinding *rbacv1.RoleBinding) bool {
 	return true
 }
 
-func (c *Controller) hasEmployeeOnlyFeatures(profile *v1.Profile, pods []*corev1.Pod) bool {
+func (c *Controller) hasEmployeeOnlyFeatures(pods []*corev1.Pod) bool {
 	// label to set
 	hasEmpOnlyFeatures := false
 
@@ -65,7 +65,7 @@ func (c *Controller) hasEmployeeOnlyFeatures(profile *v1.Profile, pods []*corev1
 	return hasEmpOnlyFeatures
 }
 
-func (c *Controller) isNonEmployeeUser(profile *v1.Profile, roleBindings []*rbacv1.RoleBinding) bool {
+func (c *Controller) hasNonEmployeeUser(roleBindings []*rbacv1.RoleBinding) bool {
 	// label to set
 	nonEmployeeUser := false
 

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -1,0 +1,141 @@
+/*
+These tests make use of hasEmployeeOnlyFeatures and isNonEmployeeUser with mocked rolebindings and pods.
+
+Can parse Pod/RoleBinding specs from YAML files in tests/ folder and use the same YAML files to do an E2E
+test against a local k8s cluster like k3d.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+//        _   _ _
+//  _   _| |_(_) |___
+// | | | | __| | / __|
+// | |_| | |_| | \__ \
+// \__,_|\__|_|_|___/
+
+const TEST_DIRECTORY = "../../tests/"
+
+var mockController = Controller{}
+
+// Load kubernetes object from YAML file
+func loadObjectFromYaml(filePath string) (runtime.Object, error) {
+	yamlFile, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode([]byte(yamlFile), nil, nil)
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
+		return nil, err
+	}
+	return obj, err
+}
+
+// Load pod spec from yaml file
+func getPod(filePath string) (*corev1.Pod, error) {
+	obj, _ := loadObjectFromYaml(filePath)
+	pod := obj.(*corev1.Pod)
+	return pod, nil
+}
+
+// Load all pods in a test folder
+func getPods(filePath string) ([]*corev1.Pod, error) {
+	// Initialize list of pods
+	pods := []*corev1.Pod{}
+	items, _ := ioutil.ReadDir(filePath)
+	// Load each pod in
+	for _, item := range items {
+		pod, _ := getPod(filepath.Join(filePath, item.Name()))
+		pods = append(pods, pod)
+	}
+	return pods, nil
+}
+
+// Load rolebinding spec from yaml file
+func getRolebinding(filePath string) (*rbacv1.RoleBinding, error) {
+	obj, _ := loadObjectFromYaml(filePath)
+	rolebinding := obj.(*rbacv1.RoleBinding)
+	return rolebinding, nil
+}
+
+// Load all rolebindings in a test folder
+func getRolebindings(filePath string) ([]*rbacv1.RoleBinding, error) {
+	// Initialize list of pods
+	rolebindings := []*rbacv1.RoleBinding{}
+	items, _ := ioutil.ReadDir(filePath)
+	// Load each pod in
+	for _, item := range items {
+		rolebinding, _ := getRolebinding(filepath.Join(filePath, item.Name()))
+		rolebindings = append(rolebindings, rolebinding)
+	}
+	return rolebindings, nil
+}
+
+//  _            _
+// | |_ ___  ___| |_ ___
+// | __/ _ \/ __| __/ __|
+// | ||  __/\__ \ |_\__ \
+//  \__\___||___/\__|___/
+
+// If any pod in the list uses a SAS image, hasEmployeeOnlyFeatures should return true
+func TestAnyPodWithSASImageReturnsTrue(t *testing.T) {
+	pods, _ := getPods(filepath.Join(TEST_DIRECTORY, "1"))
+	result := mockController.hasEmployeeOnlyFeatures(pods)
+	if !result {
+		t.Fatalf("Expected hasEmployeeOnlyFeatures to return true because at least one pod contains a SAS image.")
+	}
+}
+
+func TestNoPodWithSASImageReturnsFalse(t *testing.T) {
+	pods, _ := getPods(filepath.Join(TEST_DIRECTORY, "2"))
+	result := mockController.hasEmployeeOnlyFeatures(pods)
+	if result {
+		t.Fatalf("Expected hasEmployeeOnlyFeatures to return false because no pods contain a SAS image.")
+	}
+}
+
+func TestEmptyPodListReturnsFalse(t *testing.T) {
+	pods := []*corev1.Pod{}
+	result := mockController.hasEmployeeOnlyFeatures(pods)
+	if result {
+		t.Fatalf("Expected hasEmployeeOnlyFeatures to return false because empty list of pods can't contain SAS image.")
+	}
+}
+
+func TestAnyRolebindingWithNonEmployeeReturnsTrue(t *testing.T) {
+	rolebindings, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "4"))
+	result := mockController.hasNonEmployeeUser(rolebindings)
+	if !result {
+		t.Fatalf("Expected hasNonEmployeeUser to return true because at least one rolebinding contains a non-employee user.")
+	}
+}
+
+func TestNoRolebindingWithNonEmployeeReturnsFalse(t *testing.T) {
+	rolebindings, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "5"))
+	result := mockController.hasNonEmployeeUser(rolebindings)
+	if result {
+		t.Fatalf("Expected hasNonEmployeeUser to return false because no rolebindings contain a non-employee user.")
+	}
+}
+
+func TestEmptyRolebindingListReturnsFalse(t *testing.T) {
+	rolebindings := []*rbacv1.RoleBinding{}
+	result := mockController.hasNonEmployeeUser(rolebindings)
+	if result {
+		t.Fatalf("Expected hasNonEmployeeUser to return false because empty list of rolebindings contain a non-employee user.")
+	}
+}

--- a/pkg/controller/test_handler.go
+++ b/pkg/controller/test_handler.go
@@ -1,0 +1,8 @@
+/*
+These tests make use of hasEmployeeOnlyFeatures and isNonEmployeeUser with mocked rolebindings and pods.
+
+Can parse Pod/RoleBinding specs from YAML files in tests/ folder and use the same YAML files to do an E2E
+test against a local k8s cluster like k3d.
+*/
+
+package controller

--- a/pkg/controller/test_handler.go
+++ b/pkg/controller/test_handler.go
@@ -1,8 +1,0 @@
-/*
-These tests make use of hasEmployeeOnlyFeatures and isNonEmployeeUser with mocked rolebindings and pods.
-
-Can parse Pod/RoleBinding specs from YAML files in tests/ folder and use the same YAML files to do an E2E
-test against a local k8s cluster like k3d.
-*/
-
-package controller

--- a/tests/1/1_pod_has_no_sas_image.yaml
+++ b/tests/1/1_pod_has_no_sas_image.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alice-jupyter
+  namespace: alice
+spec:
+  containers:
+    - name: alice
+      image: "jupyter/datascience-notebook"
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/tests/1/2_pod_has_sas_image.yaml
+++ b/tests/1/2_pod_has_sas_image.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alice-sas
+  namespace: alice
+spec:
+  containers:
+    - name: alice
+      image: "k8scc01covidacr.azurecr.io/sas:452"
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/tests/2/1_pod_has_no_sas_image.yaml
+++ b/tests/2/1_pod_has_no_sas_image.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alice-jupyter-1
+  namespace: alice
+spec:
+  containers:
+    - name: alice
+      image: "jupyter/datascience-notebook"
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/tests/2/2_pod_has_no_sas_image.yaml
+++ b/tests/2/2_pod_has_no_sas_image.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alice-jupyter-2
+  namespace: alice
+spec:
+  containers:
+    - name: alice
+      image: "jupyter/datascience-notebook"
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/tests/4/1_rolebinding_employee.yaml
+++ b/tests/4/1_rolebinding_employee.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: sam@statcan.gc.ca
+  name: user-sam-statcan
+  namespace: sam
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: sam@statcan.gc.ca

--- a/tests/4/2_rolebinding_non_employee.yaml
+++ b/tests/4/2_rolebinding_non_employee.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: test@external.ca
+  name: user-test-external
+  namespace: sam
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: test@external.ca

--- a/tests/5/1_rolebinding_employee.yaml
+++ b/tests/5/1_rolebinding_employee.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: bob@statcan.gc.ca
+  name: user-bob-external
+  namespace: bob
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: bob@statcan.gc.ca

--- a/tests/5/2_rolebinding_employee.yaml
+++ b/tests/5/2_rolebinding_employee.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: alice@cloud.statcan.ca
+  name: user-alice-internal
+  namespace: alice
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: alice@cloud.statcan.ca


### PR DESCRIPTION
# Description

Refactor profile state controller to add the same labels added to the Kubeflow profiles to the corresponding Kubernetes namespaces.

Closes https://github.com/StatCan/daaas/issues/1107

## TODO

- [x] Implement namespace label feature
- [x] Refactor `handler.go` so that core logic is testable
- [x] Write unit tests against core logic
- [x] Unit tests passing
- [x] Do E2E test on dev cluster (verified on dev cluster that namespaces received the same labels as profiles and that this worked for both employees and non-employees)