### PR TITLE
@cbrown/1335 non employee rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ If any Pods in that namespace are using a SAS image, it will set the label in th
 
 ### Unit Test Cases
 
-1. If **any pod** in a list of pods contains a SAS image, `hasEmployeeOnlyFeatures` should return `true`.
-2. If **no pod** in a list of pods contains a SAS image,  `hasEmployeeOnlyFeatures` should return `false`.
-3. If an empty list is passed to `hasEmployeeOnlyFeatures`, it should return `false`.
+1. If **any pod** in a list of pods contains a SAS image, `hasSasNotebookFeature` should return `true`.
+2. If **no pod** in a list of pods contains a SAS image,  `hasSasNotebookFeature` should return `false`.
+3. If an empty list is passed to `hasSasNotebookFeature`, it should return `false`.
 
 ## Non-Employee Users
 
@@ -33,9 +33,9 @@ Other applications on the cluster can use this label to make decisions based on 
 
 ### Unit Test Cases
 
-1. If **any rolebinding** in a list of rolebindings contains a non-employee user, `hasNonEmployeeUser` should return `true`.
-2. If **no rolebinding** in a list of rolebindings contains a non-employee user, `hasNonEmployeeUser` should return `false`.
-3. If an empty list is passed to `hasNonEmployeeUser`, it should return `false`.
+1. If **any rolebinding** in a list of rolebindings contains a non-employee user, `existsNonSasUser` should return `true`.
+2. If **no rolebinding** in a list of rolebindings contains a non-employee user, `existsNonSasUser` should return `false`.
+3. If an empty list is passed to `existsNonSasUser`, it should return `false`.
 
 
 The Gatekeeper Policies check for these labels in the Profile and allow objects to be created or denied accordingly. More information about these policies and how the objects interact can be found in their README in the Gatekeeper Policies repository (linked below).

--- a/cluster/configmap.yaml
+++ b/cluster/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: non-employee-exceptions
+  namespace: statcan-system
+data:
+  'non-employee-exceptions.yaml': |-
+    cloudMainExceptions:
+    - john.doe@external.ca
+    - jane.doe@notanemployee.ca
+    sasNotebookExceptions:
+    - alice.smith@external.ca
+    - jane.doe@notanemployee.ca
+  

--- a/pkg/controller/configmap_loader.go
+++ b/pkg/controller/configmap_loader.go
@@ -1,0 +1,24 @@
+package controller
+
+import (
+	"io/ioutil"
+	"log"
+
+	"gopkg.in/yaml.v2"
+)
+
+func UnmarshalConf(configmapPath string) map[string][]string {
+	yfile, err := ioutil.ReadFile(configmapPath)
+	if err != nil {
+		log.Println(err)
+	}
+
+	conf := make(map[string][]string)
+
+	err2 := yaml.Unmarshal(yfile, &conf)
+	if err2 != nil {
+		log.Println(err2)
+	}
+
+	return conf
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -243,12 +243,13 @@ func (c *Controller) syncHandler(key string) error {
 	if err != nil {
 		return err
 	}
-	// Get the status of the profile/namespace
-	hasEmployeeOnlyFeatures := c.hasEmployeeOnlyFeatures(pods)
+	// Handle SAS labels for namespace
+	hasSasNotebookFeature := c.hasSasNotebookFeature(pods)
+	existsNonSasUser := c.existsNonSasUser(roleBindings)
+	// Handle cloud main labels for namespace
+	existsNonCloudMainUser := c.existsNonCloudMainUser(roleBindings)
 
-	isNonEmployeeUser := c.hasNonEmployeeUser(roleBindings)
-	// Handle the profile
-	err = c.handleProfileAndNamespace(profile, namespace, hasEmployeeOnlyFeatures, isNonEmployeeUser)
+	err = c.handleProfileAndNamespace(profile, namespace, hasSasNotebookFeature, existsNonSasUser, existsNonCloudMainUser)
 	if err != nil {
 		log.Errorf("failed to handle profile or namespace: %v", err)
 		return err

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -54,6 +54,8 @@ type Controller struct {
 
 	workqueue workqueue.RateLimitingInterface
 	recorder  record.EventRecorder
+
+	nonEmployeeExceptions map[string][]string
 }
 
 // NewController creates a new Controller object.
@@ -87,6 +89,7 @@ func NewController(
 		roleBindingSynced:       roleBindingInformer.Informer().HasSynced,
 		workqueue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "PodPolicy"),
 		recorder:                recorder,
+		nonEmployeeExceptions:   UnmarshalConf("./app/non-employee-exceptions.yaml"),
 	}
 
 	// Set up an event handler for when Profile resources change

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -75,7 +75,7 @@ func (c *Controller) rolebindingContainsNonSasUser(rolebinding *rbacv1.RoleBindi
 		// If we get to this point, the user is not a statcan employee and the user has not
 		// been granted an exception to use the SAS feeature. This is a sufficient condition
 		// for rolebindingContainsNonSasUser to return true.
-		return false
+		return true
 	}
 	return false
 }
@@ -98,8 +98,8 @@ func (c *Controller) existsNonSasUser(roleBindings []*rbacv1.RoleBinding) bool {
 	// label to set
 	nonSasUser := false
 
-	for _, roleBindings := range roleBindings {
-		if c.rolebindingContainsNonSasUser(roleBindings) {
+	for _, roleBinding := range roleBindings {
+		if c.rolebindingContainsNonSasUser(roleBinding) {
 			nonSasUser = true
 			break
 		}
@@ -135,29 +135,29 @@ func (c *Controller) rolebindingContainsNonCloudMainUser(rolebinding *rbacv1.Rol
 		}
 		// If the subject is in the exception list for SAS users, then we can continue to the next
 		// iteration
-		if c.subjectInSasNotebookExceptionList(subject.Name) {
+		if c.subjectInCloudMainExceptionList(subject.Name) {
 			continue
 		}
 		// If we get to this point, the user is not a statcan employee and the user has not
 		// been granted an exception to use the SAS feeature. This is a sufficient condition
 		// for rolebindingContainsNonSasUser to return true.
-		return false
+		return true
 	}
 	return false
 }
 
 func (c *Controller) existsNonCloudMainUser(roleBindings []*rbacv1.RoleBinding) bool {
 	// label to set
-	nonSasUser := false
+	nonCloudMainUser := false
 
-	for _, roleBindings := range roleBindings {
-		if !c.rolebindingContainsNonSasUser(roleBindings) {
-			nonSasUser = true
+	for _, roleBinding := range roleBindings {
+		if c.rolebindingContainsNonCloudMainUser(roleBinding) {
+			nonCloudMainUser = true
 			break
 		}
 	}
 
-	return nonSasUser
+	return nonCloudMainUser
 }
 
 //              _                     _ _

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -71,7 +71,7 @@ func (c *Controller) rolebindingContainsNonSasUser(rolebinding *rbacv1.RoleBindi
 		// iteration
 		if c.subjectInSasNotebookExceptionList(subject.Name) {
 			continue
-	}
+		}
 		// If we get to this point, the user is not a statcan employee and the user has not
 		// been granted an exception to use the SAS feeature. This is a sufficient condition
 		// for rolebindingContainsNonSasUser to return true.

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -160,7 +160,13 @@ func (c *Controller) existsNonCloudMainUser(roleBindings []*rbacv1.RoleBinding) 
 	return nonSasUser
 }
 
-func (c *Controller) handleProfileAndNamespace(profile *v1.Profile, namespace *corev1.Namespace, hasEmployeeOnlyFeatures bool, isNonEmployeeUser bool) error {
+//              _                     _ _
+//  _ __  ___  | |__   __ _ _ __   __| | | ___ _ __
+// | '_ \/ __| | '_ \ / _` | '_ \ / _` | |/ _ \ '__|
+// | | | \__ \ | | | | (_| | | | | (_| | |  __/ |
+// |_| |_|___/ |_| |_|\__,_|_| |_|\__,_|_|\___|_|
+
+func (c *Controller) handleProfileAndNamespace(profile *v1.Profile, namespace *corev1.Namespace, hasSasNotebookFeature bool, existsNonSasUser bool, existsNonCloudMainUser bool) error {
 	// set namespace labels
 	if namespace.Labels == nil {
 		namespace.Labels = make(map[string]string)
@@ -169,11 +175,15 @@ func (c *Controller) handleProfileAndNamespace(profile *v1.Profile, namespace *c
 	if profile.Labels == nil {
 		profile.Labels = make(map[string]string)
 	}
-	// Update profile and namespace labels
-	profile.Labels[FEATURES_LABEL] = strconv.FormatBool(hasEmployeeOnlyFeatures)
-	profile.Labels[RB_LABEL] = strconv.FormatBool(isNonEmployeeUser)
-	namespace.Labels[FEATURES_LABEL] = strconv.FormatBool(hasEmployeeOnlyFeatures)
-	namespace.Labels[RB_LABEL] = strconv.FormatBool(isNonEmployeeUser)
+	// Update profile labels
+	profile.Labels[HAS_SAS_NOTEBOOK_FEATURE_LABEL] = strconv.FormatBool(hasSasNotebookFeature)
+	profile.Labels[EXISTS_NON_SAS_NOTEBOOK_USER_LABEL] = strconv.FormatBool(existsNonSasUser)
+	profile.Labels[EXISTS_NON_CLOUD_MAIN_USER_LABEL] = strconv.FormatBool(existsNonCloudMainUser)
+
+	// Update namespace labels
+	namespace.Labels[HAS_SAS_NOTEBOOK_FEATURE_LABEL] = strconv.FormatBool(hasSasNotebookFeature)
+	namespace.Labels[EXISTS_NON_SAS_NOTEBOOK_USER_LABEL] = strconv.FormatBool(existsNonSasUser)
+	namespace.Labels[EXISTS_NON_CLOUD_MAIN_USER_LABEL] = strconv.FormatBool(existsNonCloudMainUser)
 
 	ctx := context.Background()
 	// Update profile and namespace resources

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -13,10 +13,19 @@ import (
 )
 
 const SAS_PREFIX = "k8scc01covidacr.azurecr.io/sas:"
-const FEATURES_LABEL = "state.aaw.statcan.gc.ca/employee-only-features"
-const RB_LABEL = "state.aaw.statcan.gc.ca/non-employee-users"
+
+// Declare capability labels
+const HAS_SAS_NOTEBOOK_FEATURE_LABEL = "state.aaw.statcan.gc.ca/has-sas-notebook-feature"
+const EXISTS_NON_SAS_NOTEBOOK_USER_LABEL = "state.aaw.statcan.gc.ca/exists-non-sas-notebook-user"
+const EXISTS_NON_CLOUD_MAIN_USER_LABEL = "state.aaw.statcan.gc.ca/exists-non-cloud-main-user"
 
 var employeeDomains [2]string = [2]string{"cloud.statcan.ca", "statcan.gc.ca"}
+
+//  ____    _    ____    _   _       _       _                 _
+// / ___|  / \  / ___|  | \ | | ___ | |_ ___| |__   ___   ___ | | __
+// \___ \ / _ \ \___ \  |  \| |/ _ \| __/ _ \ '_ \ / _ \ / _ \| |/ /
+//  ___) / ___ \ ___) | | |\  | (_) | ||  __/ |_) | (_) | (_) |   <
+// |____/_/   \_\____/  |_| \_|\___/ \__\___|_.__/ \___/ \___/|_|\_\
 
 func sasImage(pod *corev1.Pod) bool {
 
@@ -39,44 +48,116 @@ func internalUser(email string) bool {
 	return false
 }
 
-func isEmployee(rolebinding *rbacv1.RoleBinding) bool {
-	for _, subject := range rolebinding.Subjects {
-		email := subject.Name
-		if strings.Contains(email, "@") {
-			if !internalUser(email) {
-				return false
-			}
+func (c *Controller) subjectInSasNotebookExceptionList(subject string) bool {
+	for _, exceptionCase := range c.nonEmployeeExceptions["sasNotebookExceptions"] {
+		if subject == exceptionCase {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
-func (c *Controller) hasEmployeeOnlyFeatures(pods []*corev1.Pod) bool {
+func (c *Controller) rolebindingContainsNonSasUser(rolebinding *rbacv1.RoleBinding) bool {
+	for _, subject := range rolebinding.Subjects {
+		// If the subject contains a Statcan employee email, there is nothing more to check.
+		// Continue to the next iteration
+		email := subject.Name
+		if strings.Contains(email, "@") {
+			if internalUser(email) {
+				continue
+			}
+		}
+		// If the subject is in the exception list for SAS users, then we can continue to the next
+		// iteration
+		if c.subjectInSasNotebookExceptionList(subject.Name) {
+			continue
+	}
+		// If we get to this point, the user is not a statcan employee and the user has not
+		// been granted an exception to use the SAS feeature. This is a sufficient condition
+		// for rolebindingContainsNonSasUser to return true.
+		return false
+	}
+	return false
+}
+
+func (c *Controller) hasSasNotebookFeature(pods []*corev1.Pod) bool {
 	// label to set
-	hasEmpOnlyFeatures := false
+	hasSasNotebookFeature := false
 
 	for _, pod := range pods {
 		if sasImage(pod) {
-			hasEmpOnlyFeatures = true
+			hasSasNotebookFeature = true
 			break
 		}
 	}
 
-	return hasEmpOnlyFeatures
+	return hasSasNotebookFeature
 }
 
-func (c *Controller) hasNonEmployeeUser(roleBindings []*rbacv1.RoleBinding) bool {
+func (c *Controller) existsNonSasUser(roleBindings []*rbacv1.RoleBinding) bool {
 	// label to set
-	nonEmployeeUser := false
+	nonSasUser := false
 
 	for _, roleBindings := range roleBindings {
-		if !isEmployee(roleBindings) {
-			nonEmployeeUser = true
+		if c.rolebindingContainsNonSasUser(roleBindings) {
+			nonSasUser = true
 			break
 		}
 	}
 
-	return nonEmployeeUser
+	return nonSasUser
+}
+
+//       _                 _                   _
+//   ___| | ___  _   _  __| |  _ __ ___   __ _(_)_ __
+//  / __| |/ _ \| | | |/ _` | | '_ ` _ \ / _` | | '_ \
+// | (__| | (_) | |_| | (_| | | | | | | | (_| | | | | |
+//  \___|_|\___/ \__,_|\__,_| |_| |_| |_|\__,_|_|_| |_|
+
+func (c *Controller) subjectInCloudMainExceptionList(subject string) bool {
+	for _, exceptionCase := range c.nonEmployeeExceptions["cloudMainExceptions"] {
+		if subject == exceptionCase {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Controller) rolebindingContainsNonCloudMainUser(rolebinding *rbacv1.RoleBinding) bool {
+	for _, subject := range rolebinding.Subjects {
+		// If the subject contains a Statcan employee email, there is nothing more to check.
+		// Continue to the next iteration
+		email := subject.Name
+		if strings.Contains(email, "@") {
+			if internalUser(email) {
+				continue
+			}
+		}
+		// If the subject is in the exception list for SAS users, then we can continue to the next
+		// iteration
+		if c.subjectInSasNotebookExceptionList(subject.Name) {
+			continue
+		}
+		// If we get to this point, the user is not a statcan employee and the user has not
+		// been granted an exception to use the SAS feeature. This is a sufficient condition
+		// for rolebindingContainsNonSasUser to return true.
+		return false
+	}
+	return false
+}
+
+func (c *Controller) existsNonCloudMainUser(roleBindings []*rbacv1.RoleBinding) bool {
+	// label to set
+	nonSasUser := false
+
+	for _, roleBindings := range roleBindings {
+		if !c.rolebindingContainsNonSasUser(roleBindings) {
+			nonSasUser = true
+			break
+		}
+	}
+
+	return nonSasUser
 }
 
 func (c *Controller) handleProfileAndNamespace(profile *v1.Profile, namespace *corev1.Namespace, hasEmployeeOnlyFeatures bool, isNonEmployeeUser bool) error {

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -1,5 +1,5 @@
 /*
-These tests make use of hasEmployeeOnlyFeatures and isNonEmployeeUser with mocked rolebindings and pods.
+These tests make use of hasSasNotebookFeature and existsNonSasUser with mocked rolebindings and pods.
 
 Can parse Pod/RoleBinding specs from YAML files in tests/ folder and use the same YAML files to do an E2E
 test against a local k8s cluster like k3d.
@@ -93,51 +93,51 @@ func getRolebindings(filePath string) ([]*rbacv1.RoleBinding, error) {
 // | ||  __/\__ \ |_\__ \
 //  \__\___||___/\__|___/
 
-// If any pod in the list uses a SAS image, hasEmployeeOnlyFeatures should return true
+// If any pod in the list uses a SAS image, hasSasNotebookFeature should return true
 func TestAnyPodWithSASImageReturnsTrue(t *testing.T) {
 	pods, _ := getPods(filepath.Join(TEST_DIRECTORY, "1"))
-	result := mockController.hasEmployeeOnlyFeatures(pods)
+	result := mockController.hasSasNotebookFeature(pods)
 	if !result {
-		t.Fatalf("Expected hasEmployeeOnlyFeatures to return true because at least one pod contains a SAS image.")
+		t.Fatalf("Expected hasSasNotebookFeature to return true because at least one pod contains a SAS image.")
 	}
 }
 
 func TestNoPodWithSASImageReturnsFalse(t *testing.T) {
 	pods, _ := getPods(filepath.Join(TEST_DIRECTORY, "2"))
-	result := mockController.hasEmployeeOnlyFeatures(pods)
+	result := mockController.hasSasNotebookFeature(pods)
 	if result {
-		t.Fatalf("Expected hasEmployeeOnlyFeatures to return false because no pods contain a SAS image.")
+		t.Fatalf("Expected hasSasNotebookFeature to return false because no pods contain a SAS image.")
 	}
 }
 
 func TestEmptyPodListReturnsFalse(t *testing.T) {
 	pods := []*corev1.Pod{}
-	result := mockController.hasEmployeeOnlyFeatures(pods)
+	result := mockController.hasSasNotebookFeature(pods)
 	if result {
-		t.Fatalf("Expected hasEmployeeOnlyFeatures to return false because empty list of pods can't contain SAS image.")
+		t.Fatalf("Expected hasSasNotebookFeature to return false because empty list of pods can't contain SAS image.")
 	}
 }
 
 func TestAnyRolebindingWithNonEmployeeReturnsTrue(t *testing.T) {
 	rolebindings, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "4"))
-	result := mockController.hasNonEmployeeUser(rolebindings)
+	result := mockController.existsNonSasUser(rolebindings)
 	if !result {
-		t.Fatalf("Expected hasNonEmployeeUser to return true because at least one rolebinding contains a non-employee user.")
+		t.Fatalf("Expected existsNonSasUser to return true because at least one rolebinding contains a non-employee user.")
 	}
 }
 
 func TestNoRolebindingWithNonEmployeeReturnsFalse(t *testing.T) {
 	rolebindings, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "5"))
-	result := mockController.hasNonEmployeeUser(rolebindings)
+	result := mockController.existsNonSasUser(rolebindings)
 	if result {
-		t.Fatalf("Expected hasNonEmployeeUser to return false because no rolebindings contain a non-employee user.")
+		t.Fatalf("Expected existsNonSasUser to return false because no rolebindings contain a non-employee user.")
 	}
 }
 
 func TestEmptyRolebindingListReturnsFalse(t *testing.T) {
 	rolebindings := []*rbacv1.RoleBinding{}
-	result := mockController.hasNonEmployeeUser(rolebindings)
+	result := mockController.existsNonSasUser(rolebindings)
 	if result {
-		t.Fatalf("Expected hasNonEmployeeUser to return false because empty list of rolebindings contain a non-employee user.")
+		t.Fatalf("Expected existsNonSasUser to return false because empty list of rolebindings contain a non-employee user.")
 	}
 }

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -28,7 +28,9 @@ import (
 
 const TEST_DIRECTORY = "../../tests/"
 
-var mockController = Controller{}
+var mockController = Controller{
+	nonEmployeeExceptions: UnmarshalConf(filepath.Join(TEST_DIRECTORY, "non-employee-exceptions.yaml")),
+}
 
 // Load kubernetes object from YAML file
 func loadObjectFromYaml(filePath string) (runtime.Object, error) {

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -141,3 +141,119 @@ func TestEmptyRolebindingListReturnsFalse(t *testing.T) {
 		t.Fatalf("Expected existsNonSasUser to return false because empty list of rolebindings contain a non-employee user.")
 	}
 }
+
+//    					    _   _
+//   _____  _____ ___ _ __ | |_(_) ___  _ __     ___ __ _ ___  ___  ___
+//  / _ \ \/ / __/ _ \ '_ \| __| |/ _ \| '_ \   / __/ _` / __|/ _ \/ __|
+// |  __/>  < (_|  __/ |_) | |_| | (_) | | | | | (_| (_| \__ \  __/\__ \
+//  \___/_/\_\___\___| .__/ \__|_|\___/|_| |_|  \___\__,_|___/\___||___/
+// 				    |_|
+
+// If rolebinding contains only statcan domains --> profiles-state-controller should produce the labels
+// state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: false and
+// state.aaw.statcan.gc.ca/exists-non-cloud-main-user: false
+
+func TestStatCanEmployeeOnlyReturnsFalseAndFalse(t *testing.T) {
+	rolebinding, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "exception_1"))
+	sasResult := mockController.existsNonSasUser(rolebinding)
+	cloudMainResult := mockController.existsNonCloudMainUser(rolebinding)
+	// if sasResult == False AND cloudMainResult == False, we are OK. Otherwise the test failed
+	if !sasResult && !cloudMainResult {
+		return
+	}
+	t.Fatalf("Expected state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: false and state.aaw.statcan.gc.ca/exists-non-cloud-main-user: false")
+}
+
+// If rolebinding contains statcan domains AND a user with only the SAS exception --> profiles-state-controller should
+// produce the labels state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: false and
+// state.aaw.statcan.gc.ca/exists-non-cloud-main-user: true
+
+func TestStatCanEmployeeAndSasExceptionReturnsFalseAndTrue(t *testing.T) {
+	rolebinding, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "exception_2"))
+	sasResult := mockController.existsNonSasUser(rolebinding)
+	cloudMainResult := mockController.existsNonCloudMainUser(rolebinding)
+	// if sasResult == False AND cloudMainResult == True, we are OK. Otherwise the test failed
+	if !sasResult && cloudMainResult {
+		return
+	}
+	t.Fatalf("Expected state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: false and state.aaw.statcan.gc.ca/exists-non-cloud-main-user: true")
+}
+
+// If rolebinding contains statcan domains AND a user with only the cloud main exception --> profiles-state-controller
+// should produce the labels state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true and
+// state.aaw.statcan.gc.ca/exists-non-cloud-main-user: false
+
+func TestStatCanEmployeeAndCloudMainExceptionReturnsTrueAndFalse(t *testing.T) {
+	rolebinding, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "exception_3"))
+	sasResult := mockController.existsNonSasUser(rolebinding)
+	cloudMainResult := mockController.existsNonCloudMainUser(rolebinding)
+	// if sasResult == True AND cloudMainResult == False, we are OK. Otherwise the test failed
+	if sasResult && !cloudMainResult {
+		return
+	}
+	t.Fatalf("Expected state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true and state.aaw.statcan.gc.ca/exists-non-cloud-main-user: false")
+
+}
+
+// If rolebinding contains statcan domains AND a user with only the cloud main exception AND a user with only the SAS
+// exception --> profiles-state-controller should produce the labels
+// state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true and
+// state.aaw.statcan.gc.ca/exists-non-cloud-main-user: true
+
+func TestStatCanEmployeeAndCloudMainExceptionAndSasExceptionReturnsTrueAndTrue(t *testing.T) {
+	rolebinding, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "exception_4"))
+	sasResult := mockController.existsNonSasUser(rolebinding)
+	cloudMainResult := mockController.existsNonCloudMainUser(rolebinding)
+	// if sasResult == True AND cloudMainResult == True, we are OK. Otherwise the test failed
+	if sasResult && cloudMainResult {
+		return
+	}
+	t.Fatalf("Expected state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true and state.aaw.statcan.gc.ca/exists-non-cloud-main-user: true")
+}
+
+// If rolebinding contains external employees who all have both the cloud main exception and
+// the SAS exception --> profiles-state-controller should produce the labels
+// state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: false and
+// state.aaw.statcan.gc.ca/exists-non-cloud-main-user: false
+
+func TestExternalEmployeesWithBothExceptionsReturnsFalseAndFalse(t *testing.T) {
+	rolebinding, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "exception_5"))
+	sasResult := mockController.existsNonSasUser(rolebinding)
+	cloudMainResult := mockController.existsNonCloudMainUser(rolebinding)
+	// if sasResult == False AND cloudMainResult == False, we are OK. Otherwise the test failed
+	if !sasResult && !cloudMainResult {
+		return
+	}
+	t.Fatalf("Expected state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: false and state.aaw.statcan.gc.ca/exists-non-cloud-main-user: false")
+}
+
+// If rolebinding contains only external employees who have no exceptions --> profiles-state-controller
+// should produce the labels state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true and
+// state.aaw.statcan.gc.ca/exists-non-cloud-main-user: true
+
+func TestExternalEmployeesWithNoExceptionsReturnsTrueAndTrue(t *testing.T) {
+	rolebinding, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "exception_6"))
+	sasResult := mockController.existsNonSasUser(rolebinding)
+	cloudMainResult := mockController.existsNonCloudMainUser(rolebinding)
+	// if sasResult == True AND cloudMainResult == True, we are OK. Otherwise the test failed
+	if sasResult && cloudMainResult {
+		return
+	}
+	t.Fatalf("Expected state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true and state.aaw.statcan.gc.ca/exists-non-cloud-main-user: true")
+}
+
+// If a rolebinding contains StatCan employees AND a single external employee with no
+// exceptions --> profiles-state-controller should produce the labels
+// state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true and
+// state.aaw.statcan.gc.ca/exists-non-cloud-main-user: true
+
+func TestStatCanEmployeeAndUserWithNoExceptionsReturnsTrueAndTrue(t *testing.T) {
+	rolebinding, _ := getRolebindings(filepath.Join(TEST_DIRECTORY, "exception_7"))
+	sasResult := mockController.existsNonSasUser(rolebinding)
+	cloudMainResult := mockController.existsNonCloudMainUser(rolebinding)
+	// if sasResult == True AND cloudMainResult == True, we are OK. Otherwise the test failed
+	if sasResult && cloudMainResult {
+		return
+	}
+	t.Fatalf("Expected state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true and state.aaw.statcan.gc.ca/exists-non-cloud-main-user: true")
+}

--- a/tests/exception_1/1_rolebinding_employee.yaml
+++ b/tests/exception_1/1_rolebinding_employee.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: bob@statcan.gc.ca
+  name: user-bob-external
+  namespace: bob
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: bob@statcan.gc.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: john.doe@cloud.statcan.ca

--- a/tests/exception_2/1_rolebinding_employee.yaml
+++ b/tests/exception_2/1_rolebinding_employee.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: bob@statcan.gc.ca
+  name: user-bob-external
+  namespace: bob
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: bob@statcan.gc.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: john.doe@cloud.statcan.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: alice.smith@external.ca

--- a/tests/exception_3/1_rolebinding_employee.yaml
+++ b/tests/exception_3/1_rolebinding_employee.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: bob@statcan.gc.ca
+  name: user-bob-external
+  namespace: bob
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: bob@statcan.gc.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: john.doe@cloud.statcan.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: john.doe@external.ca

--- a/tests/exception_4/1_rolebinding_employee.yaml
+++ b/tests/exception_4/1_rolebinding_employee.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: bob@statcan.gc.ca
+  name: user-bob-external
+  namespace: bob
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: bob@statcan.gc.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: john.doe@cloud.statcan.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: john.doe@external.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: alice.smith@external.ca

--- a/tests/exception_5/1_rolebinding_employee.yaml
+++ b/tests/exception_5/1_rolebinding_employee.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: bob@statcan.gc.ca
+  name: user-bob-external
+  namespace: bob
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: jane.doe@notanemployee.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: bob.johnson@notanemployee.ca

--- a/tests/exception_6/1_rolebinding_employee.yaml
+++ b/tests/exception_6/1_rolebinding_employee.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: jannet@noexceptions.com
+  name: user-bob-external
+  namespace: bob
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: jannet@noexceptions.com
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: adam@notanemployee.com

--- a/tests/exception_7/1_rolebinding_employee.yaml
+++ b/tests/exception_7/1_rolebinding_employee.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: jannet@noexceptions.com
+  name: user-bob-external
+  namespace: bob
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: jane.smith@statcan.gc.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: john.smith@cloud.statcan.ca
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: adam@notanemployee.com

--- a/tests/non-employee-exceptions.yaml
+++ b/tests/non-employee-exceptions.yaml
@@ -1,6 +1,8 @@
 cloudMainExceptions:
 - john.doe@external.ca
 - jane.doe@notanemployee.ca
+- bob.johnson@notanemployee.ca
 sasNotebookExceptions:
 - alice.smith@external.ca
 - jane.doe@notanemployee.ca
+- bob.johnson@notanemployee.ca

--- a/tests/non-employee-exceptions.yaml
+++ b/tests/non-employee-exceptions.yaml
@@ -1,0 +1,6 @@
+cloudMainExceptions:
+- john.doe@external.ca
+- jane.doe@notanemployee.ca
+sasNotebookExceptions:
+- alice.smith@external.ca
+- jane.doe@notanemployee.ca


### PR DESCRIPTION
# Description

Addresses https://github.com/StatCan/daaas/issues/1335

Refactor profile state controller to apply capability-based labels instead of employee/non-employee