### PR TITLE
fix(handler.go): exception and label log verbosity

### DIFF
--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -50,7 +50,7 @@ func internalUser(email string) bool {
 
 func (c *Controller) subjectInSasNotebookExceptionList(subject string) bool {
 	for _, exceptionCase := range c.nonEmployeeExceptions["sasNotebookExceptions"] {
-		if subject == exceptionCase {
+		if subject == strings.TrimSpace(exceptionCase) {
 			return true
 		}
 	}
@@ -121,7 +121,7 @@ func (c *Controller) existsNonSasUser(roleBindings []*rbacv1.RoleBinding) bool {
 
 func (c *Controller) subjectInCloudMainExceptionList(subject string) bool {
 	for _, exceptionCase := range c.nonEmployeeExceptions["cloudMainExceptions"] {
-		if subject == exceptionCase {
+		if subject == strings.TrimSpace(exceptionCase) {
 			return true
 		}
 	}

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -203,7 +203,7 @@ func (c *Controller) handleProfileAndNamespace(profile *v1.Profile, namespace *c
 		return err
 	}
 
-	log.Infof("Updated profile %v with labels hasSasNotebookFeature=%b existsNonSasUser=%b existsNonCloudMainUser=%b",
+	log.Infof("Updated profile %v with labels hasSasNotebookFeature=%t existsNonSasUser=%t existsNonCloudMainUser=%t",
 		namespace.Name, hasSasNotebookFeature, existsNonSasUser, existsNonCloudMainUser)
 
 	_, err = c.kubeclientset.CoreV1().Namespaces().Update(ctx, namespace, metav1.UpdateOptions{})
@@ -212,7 +212,7 @@ func (c *Controller) handleProfileAndNamespace(profile *v1.Profile, namespace *c
 		return err
 	}
 
-	log.Infof("Updated namespace %v with labels hasSasNotebookFeature=%b existsNonSasUser=%b existsNonCloudMainUser=%b",
+	log.Infof("Updated namespace %v with labels hasSasNotebookFeature=%t existsNonSasUser=%t existsNonCloudMainUser=%t",
 		namespace.Name, hasSasNotebookFeature, existsNonSasUser, existsNonCloudMainUser)
 
 	return nil

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -54,6 +54,7 @@ func (c *Controller) subjectInSasNotebookExceptionList(subject string) bool {
 			return true
 		}
 	}
+	log.Infof("Found unexcepted SAS user %v", subject)
 	return false
 }
 
@@ -124,6 +125,7 @@ func (c *Controller) subjectInCloudMainExceptionList(subject string) bool {
 			return true
 		}
 	}
+	log.Infof("Found unexcepted cloudmain user %v", subject)
 	return false
 }
 
@@ -201,7 +203,8 @@ func (c *Controller) handleProfileAndNamespace(profile *v1.Profile, namespace *c
 		return err
 	}
 
-	log.Infof("Updated profile %v with labels", namespace.Name)
+	log.Infof("Updated profile %v with labels hasSasNotebookFeature=%b existsNonSasUser=%b existsNonCloudMainUser=%b",
+		namespace.Name, hasSasNotebookFeature, existsNonSasUser, existsNonCloudMainUser)
 
 	_, err = c.kubeclientset.CoreV1().Namespaces().Update(ctx, namespace, metav1.UpdateOptions{})
 
@@ -209,7 +212,8 @@ func (c *Controller) handleProfileAndNamespace(profile *v1.Profile, namespace *c
 		return err
 	}
 
-	log.Infof("Updated namespace %v with labels", namespace.Name)
+	log.Infof("Updated namespace %v with labels hasSasNotebookFeature=%b existsNonSasUser=%b existsNonCloudMainUser=%b",
+		namespace.Name, hasSasNotebookFeature, existsNonSasUser, existsNonCloudMainUser)
 
 	return nil
 }


### PR DESCRIPTION
- Trim whitespace from exception list users
- add logging to sas and cloudmain un-excepted users found
