### PR TITLE
Feat(BlobLabels): Add logic for FDI internal bucket labels

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -243,13 +243,21 @@ func (c *Controller) syncHandler(key string) error {
 	if err != nil {
 		return err
 	}
-	// Handle SAS labels for namespace
-	hasSasNotebookFeature := c.hasSasNotebookFeature(pods)
-	existsNonSasUser := c.existsNonSasUser(roleBindings)
-	// Handle cloud main labels for namespace
-	existsNonCloudMainUser := c.existsNonCloudMainUser(roleBindings)
 
-	err = c.handleProfileAndNamespace(profile, namespace, hasSasNotebookFeature, existsNonSasUser, existsNonCloudMainUser)
+	// for extensibility, use slice to store all bools to limit params on "handleProfileAndNamespace"
+	feats := make([]bool, 4)
+
+	// Handle SAS labels for namespace
+	feats[0] = c.hasSasNotebookFeature(pods)
+	feats[1] = c.existsNonSasUser(roleBindings)
+	// Handle cloud main labels for namespace
+	feats[2] = c.existsNonCloudMainUser(roleBindings)
+	// Handle Non Employees
+	feats[3] = c.existsNonEmployee(roleBindings)
+	// Handle fdi internal storage
+	feats[4] = c.existsInternalCommonStorage(namespace)
+
+	err = c.handleProfileAndNamespace(profile, namespace, feats)
 	if err != nil {
 		log.Errorf("failed to handle profile or namespace: %v", err)
 		return err

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -245,7 +245,7 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// for extensibility, use slice to store all bools to limit params on "handleProfileAndNamespace"
-	feats := make([]bool, 4)
+	feats := make([]bool, 5)
 
 	// Handle SAS labels for namespace
 	feats[0] = c.hasSasNotebookFeature(pods)

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -188,7 +188,7 @@ func (c *Controller) existsInternalCommonStorage(namespace *corev1.Namespace) bo
 		return false
 	}
 	for _, pvc := range pvcList.Items {
-		if internalPVC(pvc.Name) {
+		if c.internalPVC(pvc.Name) {
 			return true
 		} else {
 			continue
@@ -198,7 +198,7 @@ func (c *Controller) existsInternalCommonStorage(namespace *corev1.Namespace) bo
 }
 
 // helper func to check for internal bucket name through naming convention
-func internalPVC(pvcName string) bool {
+func (c *Controller) internalPVC(pvcName string) bool {
 	return strings.Contains(pvcName, "iunc") || strings.Contains(pvcName, "iprotb")
 }
 

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -188,7 +188,7 @@ func (c *Controller) existsInternalCommonStorage(namespace *corev1.Namespace) bo
 		return false
 	}
 	for _, pvc := range pvcList.Items {
-		if isInternal(pvc.Name) {
+		if internalPVC(pvc.Name) {
 			return true
 		} else {
 			continue
@@ -198,7 +198,7 @@ func (c *Controller) existsInternalCommonStorage(namespace *corev1.Namespace) bo
 }
 
 // helper func to check for internal bucket name through naming convention
-func isInternal(pvcName string) bool {
+func internalPVC(pvcName string) bool {
 	return strings.Contains(pvcName, "iunc") || strings.Contains(pvcName, "iprotb")
 }
 

--- a/tests/blob/1/iprotb_pvc_exists.yaml
+++ b/tests/blob/1/iprotb_pvc_exists.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    blob.aaw.statcan.gc.ca/automount: "true"
+    data.statcan.gc.ca/classification: protected-b
+  name: fdi-test-iprotb-protectedb
+  namespace: test
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 10T
+  storageClassName: ""
+  volumeMode: Filesystem
+  volumeName: aaw-team-fdi-protectedb-test-iprotb
+status:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 10T
+  phase: Bound

--- a/tests/blob/1/iunc_pvc_exists.yaml
+++ b/tests/blob/1/iunc_pvc_exists.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    blob.aaw.statcan.gc.ca/automount: "true"
+    data.statcan.gc.ca/classification: unclassified
+  name: fdi-test-iunc-unclassified
+  namespace: test
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 10T
+  storageClassName: ""
+  volumeMode: Filesystem
+  volumeName: aaw-team-fdi-unclassified-test-iunc
+status:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 10T
+  phase: Bound

--- a/tests/blob/2/internal_pvc_not_exists.yaml
+++ b/tests/blob/2/internal_pvc_not_exists.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    blob.aaw.statcan.gc.ca/automount: "true"
+    data.statcan.gc.ca/classification: unclassified
+  name: fdi-test-eunc-unclassified
+  namespace: test
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 10T
+  storageClassName: ""
+  volumeMode: Filesystem
+  volumeName: aaw-team-fdi-unclassified-test-eunc
+status:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 10T
+  phase: Bound


### PR DESCRIPTION
Adds back the nonEmployeeUser label and creates a new label for internal fdi common storage. These labels will be used for https://github.com/StatCan/aaw/issues/1699