### PR TITLE
refactor(blob): use informer pattern for pvcs

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 
 	kubeflow "github.com/StatCan/kubeflow-controller/pkg/generated/clientset/versioned"
 	informers "github.com/StatCan/kubeflow-controller/pkg/generated/informers/externalversions"
-	"github.com/statcan/aaw-profile-state-controller/pkg/controller"
-	"github.com/statcan/aaw-profile-state-controller/pkg/signals"
+	"github.com/statcan/profile-state-controller/pkg/controller"
+	"github.com/statcan/profile-state-controller/pkg/signals"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 
 	kubeflow "github.com/StatCan/kubeflow-controller/pkg/generated/clientset/versioned"
 	informers "github.com/StatCan/kubeflow-controller/pkg/generated/informers/externalversions"
-	"github.com/statcan/profile-state-controller/pkg/controller"
-	"github.com/statcan/profile-state-controller/pkg/signals"
+	"github.com/statcan/aaw-profile-state-controller/pkg/controller"
+	"github.com/statcan/aaw-profile-state-controller/pkg/signals"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -54,6 +54,7 @@ func main() {
 		kubeInformerFactory.Core().V1().Namespaces(),
 		kubeInformerFactory.Core().V1().Pods(),
 		kubeInformerFactory.Rbac().V1().RoleBindings(),
+		kubeInformerFactory.Core().V1().PersistentVolumeClaims(),
 	)
 
 	kubeInformerFactory.Start(stopCh)

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -180,14 +180,9 @@ func (c *Controller) existsNonCloudMainUser(roleBindings []*rbacv1.RoleBinding) 
 // The objective here is to set labels used to prevent external employees from accessing internal FDI buckets
 // Case 1 is an Internal bucket is already mounted, if a pvc exists with "iprotb" or "iunc" in it's name
 // we know there's an internal bucket mounted and external users should be prevented from accessing it
-func (c *Controller) existsInternalCommonStorage(namespace *corev1.Namespace) bool {
+func (c *Controller) existsInternalCommonStorage(pvcSlice []*corev1.PersistentVolumeClaim) bool {
 
-	pvcList, err := c.kubeclientset.CoreV1().PersistentVolumeClaims(namespace.Name).List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		log.Infof("Encountered error %t", err)
-		return false
-	}
-	for _, pvc := range pvcList.Items {
+	for _, pvc := range pvcSlice {
 		if c.internalPVC(pvc.Name) {
 			return true
 		} else {


### PR DESCRIPTION
Refactor to use informer pattern. More performant and less load on K8s api server. 